### PR TITLE
Update dependencies for Swift 5.6 and macOS 12

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,19 +1,24 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.6
 
 import PackageDescription
 
 let package = Package(
     name: "SLaM",
+    platforms: [
+        .macOS(.v12)
+    ],     
     products: [
         .executable(name: "slam", targets: ["SLaM"])
     ],
     dependencies: [
-        .package(name: "ShellOut", url: "https://github.com/johnsundell/shellout.git", from: "2.3.0"),
+        .package(url: "https://github.com/johnsundell/shellout.git", .upToNextMajor(from: "2.3.0")),
     ],
     targets: [
-        .target(
+        .executableTarget(
             name: "SLaM",
-            dependencies: ["ShellOut"]
+            dependencies: [
+                .product(name: "ShellOut", package: "ShellOut")
+            ]
         ),
         .testTarget(
             name: "SLaMTests",

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Swift Lambda Maker, aka SLaM, is a CLI tool used for creating and packaging AWS Lambda function written in Swift. It can create a new executable Swift Package where you can start coding your Lambda as well as package that Lambda as a zipped Docker image.
 
 ## Prerequisites
-- [Swift 5.3+](https://swift.org/download/#releases)
+- [Swift 5.6+](https://swift.org/download/#releases)
 - [Docker](https://www.docker.com/get-started)
 
 ## Getting Started

--- a/Sources/SLaM/FileTemplate.swift
+++ b/Sources/SLaM/FileTemplate.swift
@@ -1,20 +1,20 @@
 enum FileTemplate {
     static func packageFileContents(packageName: String) -> String {
         """
-        // swift-tools-version:5.3
+        // swift-tools-version:5.6
 
         import PackageDescription
 
         let package = Package(
             name: "\(packageName)",
-            platforms: [.macOS(.v10_13)],
+            platforms: [.macOS(.v12)],
             products: [
                 .executable(
                     name: "\(packageName)",
                     targets: ["\(packageName)"]),
             ],
             dependencies: [
-                .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", .upToNextMajor(from: "0.3.0"))
+                .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", .upToNextMajor(from: "0.5.0"))
             ],
             targets: [
                 .target(
@@ -45,28 +45,15 @@ enum FileTemplate {
     
     static func dockerFileContents() -> String {
         """
-         FROM swiftlang/swift:nightly-5.3-amazonlinux2
-         RUN yum -y install git \\
-         libuuid-devel \\
-         libicu-devel \\
-         libedit-devel \\
-         libxml2-devel \\
-         sqlite-devel \\
-         python-devel \\
-         ncurses-devel \\
-         curl-devel \\
-         openssl-devel \\
-         tzdata \\
-         libtool \\
-         jq \\
-         tar \\
-         zip
+         FROM swift:5.6-amazonlinux2
+         RUN yum -y install git zip
         """
     }
     
     static func packageScriptFileContents() -> String {
         """
         #!/bin/bash
+
         ##===----------------------------------------------------------------------===##
         ##
         ## This source file is part of the SwiftAWSLambdaRuntime open source project
@@ -89,11 +76,13 @@ enum FileTemplate {
         rm -rf "$target"
         mkdir -p "$target"
         cp ".build/release/$executable" "$target/"
+
         # add the target deps based on ldd
         ldd ".build/release/$executable" | grep swift | awk '{print $3}' | xargs cp -Lv -t "$target"
+
         cd "$target"
         ln -s "$executable" "bootstrap"
-        zip --symlinks lambda.zip *
+        zip --symlinks ../lambda.zip *
         """
     }
 }


### PR DESCRIPTION
As discussed on the PR I closed. I am going to propose multiple PR, one at a time, with smaller set of changes.

Content of this PR
- update all dependencies for 2022 code 

Ideas I want to work on (for later)
- add Lambda deployment from SLaM (avoid to go to the console to deploy) 
- use Apple's ArgumentParser to parse command line options 
- add SAM as optional deployment option 
- add the possibility to test with Local Invocation
- add support for Lambda Function URLs (not authenticated) 

Let me know what you think.  Thanks 